### PR TITLE
fix: export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "graphql",
     "dataloader"
   ],
+  "files": [
+    "dist"
+  ],
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "esModuleInterop": true,
     "baseUrl": "./"
   },
-  "exclude": ["node_modules", "dist", "*test.ts"]
+  "exclude": ["node_modules", "dist", "*test.ts", "example"]
 }


### PR DESCRIPTION
```
❯ tree node_modules/nestjs-graphql-dataloader/
node_modules/nestjs-graphql-dataloader/
├── dist
│   └── index.js
├── package.json
├── src
│   └── index.ts
└── tsconfig.json

2 directories, 4 files

```

not found index.d.ts